### PR TITLE
Various minor database-related cleanup

### DIFF
--- a/scripts/dbshell
+++ b/scripts/dbshell
@@ -13,7 +13,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        docker-compose up -d database
+
         docker-compose \
-            run --rm database bash -c "psql -U district_builder -d district_builder"
+            exec database bash -c "psql -U district_builder -d district_builder"
     fi
 fi

--- a/scripts/migration_generate
+++ b/scripts/migration_generate
@@ -14,6 +14,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         docker-compose \
-            run --rm server yarn run start migration:generate "$@"
+            run --rm server yarn run migration:generate "$@"
     fi
 fi

--- a/src/server/migrations/1580263521268-CreateUserTable.ts
+++ b/src/server/migrations/1580263521268-CreateUserTable.ts
@@ -4,7 +4,7 @@ export class CreateUserTable1580263521268 implements MigrationInterface {
     readonly name = 'CreateUserTable1580263521268'
 
     public async up(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query(`CREATE TABLE "user" ("id" SERIAL NOT NULL, "email" character varying NOT NULL, CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`, undefined);
+        await queryRunner.query(`CREATE TABLE "user" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "email" character varying NOT NULL, CONSTRAINT "UQ_e12875dfb3b1d92d7d7c5377e22" UNIQUE ("email"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`, undefined);
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {

--- a/src/server/ormconfig.js
+++ b/src/server/ormconfig.js
@@ -1,13 +1,14 @@
 const process = require('process');
 const username = process.env.POSTGRES_USER;
 const password = process.env.POSTGRES_PASSWORD;
+const database = process.env.POSTGRES_DB;
 module.exports = {
   "type": "postgres",
   "host": "database.service.districtbuilder.internal",
   "port": 5432,
   username,
   password,
-  "database": "postgres",
+  database,
   "synchronize": true,
   "dropSchema": false,
   "logging": true,


### PR DESCRIPTION
## Overview

Spotted a couple problems while doing some testing. This PR has minor fixes for the `dbshell` and `migration_generate` command, properly uses the `.env` file for setting the PostgreSQL database, and fixes a problem with a migration.

## Testing Instructions

- `docker-compose down` to kill all of your containers (or at least just kill your database container)
- `./scripts/setup`
- `./scripts/server`
- Verify the application works as expected (maybe add a user and refresh)
- Run `./scripts/dbshell` and verify you can list the tables