### PR TITLE
Upgrade database to PostGIS 2.5 and PostgreSQL 11.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   database:
-    image: quay.io/azavea/postgis:2.4-postgres10.9-slim
+    image: quay.io/azavea/postgis:2.5-postgres11.5-slim
     environment:
       - POSTGRES_USER=districtbuilder
       - POSTGRES_PASSWORD=districtbuilder


### PR DESCRIPTION
## Overview

Upgrade the application to use PostgreSQL 11.5 in the pursuit of being on the most up-to-date version of PostgreSQL supported by RDS for PostgreSQL on AWS.

## Testing Instructions

- Destroy any existing containers (including the database)

```
docker-compose down
```

- Run `update` to ensure the database state is consistent and then `server` to bring the application up

```
./scripts/update
./scripts/server
```

- From your host run the following command, and ensure that a GeoJSON payload is returned

```
curl -s "http://localhost:3005/districts/topology/pa" | python3 -mjson.tool
```

Closes #37 