### PR TITLE
Publish container images to ECR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-63') {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,9 @@ node {
       checkout scm
     }
 
+    env.AWS_PROFILE = 'district-builder'
+    env.AWS_DEFAULT_REGION = 'us-east-1'
+
     stage('cibuild') {
       wrap([$class: 'AnsiColorBuildWrapper']) {
         sh './scripts/cibuild'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-63') {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Publish container images to Elastic Container Registry (ECR).
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        if [[ -n "${DB_AWS_ECR_ENDPOINT}" ]]; then
+            # Evaluate the return value of the get-login subcommand, which
+            # is a docker login command with temporarily ECR credentials.
+            eval "$(aws ecr get-login --no-include-email)"
+
+            docker tag "district-builder-server:${GIT_COMMIT}" \
+                "${DB_AWS_ECR_ENDPOINT}/district-builder-server:${GIT_COMMIT}"
+            docker push "${DB_AWS_ECR_ENDPOINT}/district-builder-server:${GIT_COMMIT}"
+        else
+            echo "ERROR: No DB_AWS_ECR_ENDPOINT variable defined."
+            exit 1
+        fi
+    fi
+fi


### PR DESCRIPTION
## Overview

Establishes a `cipublish` script to push container images to ECR. The `cipublish` step will run on `develop`, `release`, `test`, and `hotfix` branches.

### Notes

The `district-builder-server` ECR repository has been created manually on the District Builder AWS account.

## Testing Instructions

- Verify that the [Jenkins build](http://urbanappsci.internal.azavea.com/job/PublicMapping/job/district-builder-2/job/PR-63/5/) runs the `cipublish` step and successfully pushes an image to the ECR repository.

Closes #36 
