### PR TITLE
Configure AWS VPC and RDS with Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,11 @@ src/cli/lib
 
 # Manage build
 src/manage/lib
+
+# Terraform
+.terraform
+.terraform/
+*.tfplan
+*.tfstate
+*.tfstate.backup
+*.tfvars

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-65') {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ node {
     env.AWS_PROFILE = 'district-builder'
     env.AWS_DEFAULT_REGION = 'us-east-1'
 
-    env.DB_SETTINGS_BUCKET = 'districtbuilder-2-staging-config-us-east-1'
+    env.DB_SETTINGS_BUCKET = 'districtbuilder-staging-config-us-east-1'
 
     stage('cibuild') {
       wrap([$class: 'AnsiColorBuildWrapper']) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/') || env.BRANCH_NAME == 'PR-65') {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,8 @@ node {
     env.AWS_PROFILE = 'district-builder'
     env.AWS_DEFAULT_REGION = 'us-east-1'
 
+    env.DB_SETTINGS_BUCKET = 'districtbuilder-2-staging-config-us-east-1'
+
     stage('cibuild') {
       wrap([$class: 'AnsiColorBuildWrapper']) {
         sh './scripts/cibuild'
@@ -29,6 +31,20 @@ node {
           wrap([$class: 'AnsiColorBuildWrapper']) {
             sh './scripts/cipublish'
           }
+        }
+      }
+
+      // Plan and apply the current state of the staging infrastructure
+      // as outlined by whatever branch of the repository passes the
+      // conditional above (`develop`, `test/*`, `release/*`, `hotfix/*`).
+      stage('infra') {
+        // Use `git` to get the primary repository's current commmit SHA and
+        // set it as the value of the `GIT_COMMIT` environment variable.
+        env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+
+        wrap([$class: 'AnsiColorBuildWrapper']) {
+          sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+          sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ In order to allow for code-sharing across the frontend and backend in conjunctio
 |-------------|---------------------------------------------------------------------------|
 | `cibuild`   | Build application for staging or a release.                               |
 | `dbshell`   | Enter a database shell.                                                   |
+| `infra`     | Execute Terraform subcommands with remote state management.               |
 | `migration` | Execute TypeORM migration CLI commands.                                   |
 | `server`    | Bring up all of the services required for the project to function.        |
 | `setup`     | Setup the project's development environment.                              |

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -46,6 +46,14 @@ Here is an example `terraform.tfvars` for this project:
 project     = "DistrictBuilder 2"
 environment = "Staging"
 aws_region  = "us-east-1"
+
+aws_key_name = "districtbuilder-2-stg"
+
+external_access_cidr_block = "127.0.0.1/32"
+
+bastion_ami           = "ami-0fc61db8544a617ed"
+bastion_instance_type = "t3.nano"
+bastion_ebs_optimized = true
 ```
 
 This file lives at `s3://districtbuilder-2-staging-config-us-east-1/terraform/terraform.tfvars`.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -43,13 +43,13 @@ First, we need to make sure there is a `terraform.tfvars` file in the project se
 Here is an example `terraform.tfvars` for this project:
 
 ```hcl
-project     = "DistrictBuilder 2"
+project     = "DistrictBuilder"
 environment = "Staging"
 aws_region  = "us-east-1"
 
-aws_key_name = "districtbuilder-2-stg"
+aws_key_name = "districtbuilder-stg"
 
-r53_private_hosted_zone = "districtbuilder-2.internal"
+r53_private_hosted_zone = "districtbuilder.internal"
 
 external_access_cidr_block = "127.0.0.1/32"
 
@@ -57,13 +57,13 @@ bastion_ami           = "ami-0fc61db8544a617ed"
 bastion_instance_type = "t3.nano"
 bastion_ebs_optimized = true
 
-rds_database_identifier = districtbuilder-2-staging
+rds_database_identifier = districtbuilder-staging
 rds_database_name       = districtbuilder
 rds_database_username   = districtbuilder
 rds_database_password   = districtbuilder
 ```
 
-This file lives at `s3://districtbuilder-2-staging-config-us-east-1/terraform/terraform.tfvars`.
+This file lives at `s3://districtbuilder-staging-config-us-east-1/terraform/terraform.tfvars`.
 
 To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,66 @@
+# Deployment
+
+- [AWS Credentials](#aws-credentials)
+- [Publish Container Images](#publish-container-images)
+- [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `district-builder`:
+
+```bash
+$ aws configure --profile district-builder
+AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
+AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+Default region name [None]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Publish Container Images
+
+Before we can deploy this project's core infrastructure, we will need to build a container image and publish it somewhere accessible to Amazon's services.
+
+AWS Elastic Container Registry (ECR) is a good candidate because ECR authentication with AWS Elastic Container Service (ECS) is handled transparently.
+
+To do this, we can use the `cibuild` and `cipublish` scripts:
+
+```bash
+$ export DB_AWS_ECR_ENDPOINT=123456789012.dkr.ecr.us-east-1.amazonaws.com
+$ ./scripts/cibuild
+...
+Successfully built 20dcf93f6907
+Successfully tagged district-builder-server:a476b78
+$ ./scripts/cipublish
+...
+```
+
+## Terraform
+
+First, we need to make sure there is a `terraform.tfvars` file in the project settings bucket on S3. The `.tfvars` file is where we can change specific attributes of the project's infrastructure, not defined in the `variables.tf` file.
+
+Here is an example `terraform.tfvars` for this project:
+
+```hcl
+project     = "DistrictBuilder 2"
+environment = "Staging"
+aws_region  = "us-east-1"
+```
+
+This file lives at `s3://districtbuilder-2-staging-config-us-east-1/terraform/terraform.tfvars`.
+
+To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+$ docker-compose -f docker-compose.ci.yml run --rm terraform
+$ ./scripts/infra plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+$ ./scripts/infra apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -49,11 +49,18 @@ aws_region  = "us-east-1"
 
 aws_key_name = "districtbuilder-2-stg"
 
+r53_private_hosted_zone = "districtbuilder-2.internal"
+
 external_access_cidr_block = "127.0.0.1/32"
 
 bastion_ami           = "ami-0fc61db8544a617ed"
 bastion_instance_type = "t3.nano"
 bastion_ebs_optimized = true
+
+rds_database_identifier = districtbuilder-2-staging
+rds_database_name       = districtbuilder
+rds_database_username   = districtbuilder
+rds_database_password   = districtbuilder
 ```
 
 This file lives at `s3://districtbuilder-2-staging-config-us-east-1/terraform/terraform.tfvars`.

--- a/deployment/terraform/alarms.tf
+++ b/deployment/terraform/alarms.tf
@@ -1,0 +1,3 @@
+resource "aws_sns_topic" "global" {
+  name = "topic${replace(var.project, " ", "")}${var.environment}GlobalNotifications"
+}

--- a/deployment/terraform/alarms.tf
+++ b/deployment/terraform/alarms.tf
@@ -1,3 +1,3 @@
 resource "aws_sns_topic" "global" {
-  name = "topic${replace(var.project, " ", "")}${var.environment}GlobalNotifications"
+  name = "topic${var.environment}GlobalNotifications"
 }

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 2.55.0"
+}
+
+terraform {
+  backend "s3" {
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -1,0 +1,103 @@
+#
+# RDS resources
+#
+resource "aws_db_subnet_group" "default" {
+  name        = var.rds_database_identifier
+  description = "Private subnets for the RDS instances"
+  subnet_ids  = module.vpc.private_subnet_ids
+
+  tags = {
+    Name        = "dbsngDatabaseServer"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_db_parameter_group" "default" {
+  name        = var.rds_database_identifier
+  description = "Parameter group for the RDS instances"
+  family      = var.rds_parameter_group_family
+
+  parameter {
+    name  = "seq_page_cost"
+    value = var.rds_seq_page_cost
+  }
+
+  parameter {
+    name  = "random_page_cost"
+    value = var.rds_random_page_cost
+  }
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = var.rds_log_min_duration_statement
+  }
+
+  parameter {
+    name  = "log_connections"
+    value = var.rds_log_connections
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = var.rds_log_disconnections
+  }
+
+  parameter {
+    name  = "log_lock_waits"
+    value = var.rds_log_lock_waits
+  }
+
+  parameter {
+    name  = "log_temp_files"
+    value = var.rds_log_temp_files
+  }
+
+  parameter {
+    name  = "log_autovacuum_min_duration"
+    value = var.rds_log_autovacuum_min_duration
+  }
+
+  tags = {
+    Name        = "dbpgDatabaseServer"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+module "database" {
+  source = "github.com/azavea/terraform-aws-postgresql-rds?ref=3.0.0"
+
+  vpc_id                     = module.vpc.id
+  allocated_storage          = var.rds_allocated_storage
+  engine_version             = var.rds_engine_version
+  instance_type              = var.rds_instance_type
+  storage_type               = var.rds_storage_type
+  database_identifier        = var.rds_database_identifier
+  database_name              = var.rds_database_name
+  database_username          = var.rds_database_username
+  database_password          = var.rds_database_password
+  backup_retention_period    = var.rds_backup_retention_period
+  backup_window              = var.rds_backup_window
+  maintenance_window         = var.rds_maintenance_window
+  auto_minor_version_upgrade = var.rds_auto_minor_version_upgrade
+  final_snapshot_identifier  = var.rds_final_snapshot_identifier
+  skip_final_snapshot        = var.rds_skip_final_snapshot
+  copy_tags_to_snapshot      = var.rds_copy_tags_to_snapshot
+  multi_availability_zone    = var.rds_multi_az
+  storage_encrypted          = var.rds_storage_encrypted
+  subnet_group               = aws_db_subnet_group.default.name
+  parameter_group            = aws_db_parameter_group.default.name
+
+  alarm_cpu_threshold                = var.rds_cpu_threshold_percent
+  alarm_disk_queue_threshold         = var.rds_disk_queue_threshold
+  alarm_free_disk_threshold          = var.rds_free_disk_threshold_bytes
+  alarm_free_memory_threshold        = var.rds_free_memory_threshold_bytes
+  alarm_cpu_credit_balance_threshold = var.rds_cpu_credit_balance_threshold
+  alarm_actions                      = [aws_sns_topic.global.arn]
+  ok_actions                         = [aws_sns_topic.global.arn]
+  insufficient_data_actions          = [aws_sns_topic.global.arn]
+
+  project     = var.project
+  environment = var.environment
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,24 @@
+#
+# Private DNS resources
+#
+resource "aws_route53_zone" "internal" {
+  name = var.r53_private_hosted_zone
+
+  vpc {
+    vpc_id     = module.vpc.id
+    vpc_region = var.aws_region
+  }
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_route53_record" "database" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "database.service.${var.r53_private_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "10"
+  records = [module.database.hostname]
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -1,0 +1,12 @@
+#
+# Bastion security group resources
+#
+resource "aws_security_group_rule" "bastion_ssh_ingress" {
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = [var.external_access_cidr_block]
+
+  security_group_id = module.vpc.bastion_security_group_id
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -10,3 +10,26 @@ resource "aws_security_group_rule" "bastion_ssh_ingress" {
 
   security_group_id = module.vpc.bastion_security_group_id
 }
+
+resource "aws_security_group_rule" "bastion_rds_egress" {
+  type      = "egress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = module.vpc.bastion_security_group_id
+  source_security_group_id = module.database.database_security_group_id
+}
+
+#
+# RDS security group resources
+#
+resource "aws_security_group_rule" "rds_bastion_ingress" {
+  type      = "ingress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = module.database.database_security_group_id
+  source_security_group_id = module.vpc.bastion_security_group_id
+}

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,0 +1,17 @@
+module "vpc" {
+  source = "github.com/azavea/terraform-aws-vpc?ref=6.0.0"
+
+  name                       = "vpc${replace(var.project, " ", "")}${var.environment}"
+  region                     = var.aws_region
+  key_name                   = var.aws_key_name
+  cidr_block                 = var.vpc_cidr_block
+  private_subnet_cidr_blocks = var.vpc_private_subnet_cidr_blocks
+  public_subnet_cidr_blocks  = var.vpc_public_subnet_cidr_blocks
+  availability_zones         = var.aws_availability_zones
+  bastion_ami                = var.bastion_ami
+  bastion_instance_type      = var.bastion_instance_type
+  bastion_ebs_optimized      = var.bastion_ebs_optimized
+
+  project     = var.project
+  environment = var.environment
+}

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "github.com/azavea/terraform-aws-vpc?ref=6.0.0"
 
-  name                       = "vpc${replace(var.project, " ", "")}${var.environment}"
+  name                       = "vpc${var.project}${var.environment}"
   region                     = var.aws_region
   key_name                   = var.aws_key_name
   cidr_block                 = var.vpc_cidr_block

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -12,3 +12,45 @@ variable "aws_region" {
   default = "us-east-1"
   type    = string
 }
+
+variable "aws_availability_zones" {
+  default = ["us-east-1a", "us-east-1b"]
+  type    = list(string)
+}
+
+variable "aws_key_name" {
+  type = string
+}
+
+variable "vpc_cidr_block" {
+  default = "10.0.0.0/16"
+  type    = string
+}
+
+variable "external_access_cidr_block" {
+  type = string
+}
+
+variable "vpc_private_subnet_cidr_blocks" {
+  default = ["10.0.1.0/24", "10.0.3.0/24"]
+  type    = list(string)
+}
+
+variable "vpc_public_subnet_cidr_blocks" {
+  default = ["10.0.0.0/24", "10.0.2.0/24"]
+  type    = list(string)
+}
+
+variable "bastion_ami" {
+  type = string
+}
+
+variable "bastion_instance_type" {
+  default = "t3.nano"
+  type    = string
+}
+
+variable "bastion_ebs_optimized" {
+  default = true
+  type    = bool
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -60,7 +60,7 @@ variable "bastion_ebs_optimized" {
 }
 
 variable "rds_allocated_storage" {
-  default = "64"
+  default = "32"
   type    = string
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "project" {
-  default = "DistrictBuilder 2"
+  default = "DistrictBuilder"
   type    = string
 }
 
@@ -121,7 +121,7 @@ variable "rds_auto_minor_version_upgrade" {
 }
 
 variable "rds_final_snapshot_identifier" {
-  default = "districtbuilder-2-rds-snapshot"
+  default = "districtbuilder-rds-snapshot"
   type    = string
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -22,6 +22,10 @@ variable "aws_key_name" {
   type = string
 }
 
+variable "r53_private_hosted_zone" {
+  type = string
+}
+
 variable "vpc_cidr_block" {
   default = "10.0.0.0/16"
   type    = string
@@ -53,4 +57,160 @@ variable "bastion_instance_type" {
 variable "bastion_ebs_optimized" {
   default = true
   type    = bool
+}
+
+variable "rds_allocated_storage" {
+  default = "64"
+  type    = string
+}
+
+variable "rds_engine_version" {
+  default = "11"
+  type    = string
+}
+
+variable "rds_parameter_group_family" {
+  default = "postgres11"
+  type    = string
+}
+
+variable "rds_instance_type" {
+  default = "db.t3.micro"
+  type    = string
+}
+
+variable "rds_storage_type" {
+  default = "gp2"
+  type    = string
+}
+
+variable "rds_database_identifier" {
+  type = string
+}
+
+variable "rds_database_name" {
+  type = string
+}
+
+variable "rds_database_username" {
+  type = string
+}
+
+variable "rds_database_password" {
+  type = string
+}
+
+variable "rds_backup_retention_period" {
+  default = "30"
+  type    = string
+}
+
+variable "rds_backup_window" {
+  default = "04:00-04:30"
+  type    = string
+}
+
+variable "rds_maintenance_window" {
+  default = "sun:04:30-sun:05:30"
+  type    = string
+}
+
+variable "rds_auto_minor_version_upgrade" {
+  default = true
+  type    = bool
+}
+
+variable "rds_final_snapshot_identifier" {
+  default = "districtbuilder-2-rds-snapshot"
+  type    = string
+}
+
+variable "rds_monitoring_interval" {
+  default = "60"
+  type    = string
+}
+
+variable "rds_skip_final_snapshot" {
+  default = false
+  type    = bool
+}
+
+variable "rds_copy_tags_to_snapshot" {
+  default = true
+  type    = bool
+}
+
+variable "rds_multi_az" {
+  default = false
+  type    = bool
+}
+
+variable "rds_storage_encrypted" {
+  default = false
+  type    = bool
+}
+
+variable "rds_seq_page_cost" {
+  default = "1"
+  type    = string
+}
+
+variable "rds_random_page_cost" {
+  default = "1"
+  type    = string
+}
+
+variable "rds_log_min_duration_statement" {
+  default = "500"
+  type    = string
+}
+
+variable "rds_log_connections" {
+  default = "0"
+  type    = string
+}
+
+variable "rds_log_disconnections" {
+  default = "0"
+  type    = string
+}
+
+variable "rds_log_lock_waits" {
+  default = "1"
+  type    = string
+}
+
+variable "rds_log_temp_files" {
+  default = "500"
+  type    = string
+}
+
+variable "rds_log_autovacuum_min_duration" {
+  default = "250"
+  type    = string
+}
+
+variable "rds_cpu_threshold_percent" {
+  default = "75"
+  type    = string
+}
+
+variable "rds_disk_queue_threshold" {
+  default = "10"
+  type    = string
+}
+
+variable "rds_free_disk_threshold_bytes" {
+  default = "5000000000"
+  type    = string
+}
+
+variable "rds_free_memory_threshold_bytes" {
+  default = "128000000"
+  type    = string
+}
+
+variable "rds_cpu_credit_balance_threshold" {
+  default = "30"
+  type    = string
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "project" {
+  default = "DistrictBuilder 2"
+  type    = string
+}
+
+variable "environment" {
+  default = "Staging"
+  type    = string
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+  type    = string
+}

--- a/deployment/terraform/versions.tf
+++ b/deployment/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.13"
+}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,6 +18,6 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-district-builder}
       - GIT_COMMIT=${GIT_COMMIT:-latest}
       - DB_DEBUG=1
-      - DB_SETTINGS_BUCKET=${DB_SETTINGS_BUCKET:-districtbuilder-2-staging-config-us-east-1}
+      - DB_SETTINGS_BUCKET=${DB_SETTINGS_BUCKET:-districtbuilder-staging-config-us-east-1}
     working_dir: /usr/local/src
     entrypoint: bash

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -8,3 +8,16 @@ services:
     volumes:
       - ./:/usr/local/src
     working_dir: /usr/local/src
+
+  terraform:
+    image: quay.io/azavea/terraform:0.12.13
+    volumes:
+      - ./:/usr/local/src
+      - $HOME/.aws:/root/.aws:ro
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-district-builder}
+      - GIT_COMMIT=${GIT_COMMIT:-latest}
+      - DB_DEBUG=1
+      - DB_SETTINGS_BUCKET=${DB_SETTINGS_BUCKET:-districtbuilder-2-staging-config-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${DB_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0") COMMAND OPTION[S]
+Execute Terraform subcommands with remote state management.
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        TERRAFORM_DIR="$(dirname "$0")/../deployment/terraform"
+        echo
+        echo "Attempting to deploy application version [${GIT_COMMIT}]..."
+        echo "-----------------------------------------------------"
+        echo
+    fi
+
+    if [[ -n "${DB_SETTINGS_BUCKET}" ]]; then
+        pushd "${TERRAFORM_DIR}"
+
+        aws s3 cp "s3://${DB_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${DB_SETTINGS_BUCKET}.tfvars"
+
+        case "${1}" in
+        plan)
+            # Clear stale modules & remote state, then re-initialize
+            rm -rf .terraform terraform.tfstate*
+            terraform init \
+                -backend-config="bucket=${DB_SETTINGS_BUCKET}" \
+                -backend-config="key=terraform/state"
+
+            terraform plan \
+                -var-file="${DB_SETTINGS_BUCKET}.tfvars" \
+                -out="${DB_SETTINGS_BUCKET}.tfplan"
+            ;;
+        apply)
+            terraform apply "${DB_SETTINGS_BUCKET}.tfplan"
+            ;;
+        *)
+            echo "ERROR: I don't have support for that Terraform subcommand!"
+            exit 1
+            ;;
+        esac
+
+        popd
+    else
+        echo "ERROR: No DB_SETTINGS_BUCKET variable defined."
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Overview

Configures and deploys VPC and RDS resources.

Resolves #45 

### Notes

AWS resources have been prefixed with `districtbuilder`. #78 has been opened to track renaming old resources to `districtbuilder-classic`.

## Testing Instructions

- Confirm that the [Jenkins build](http://urbanappsci.internal.azavea.com/job/PublicMapping/job/district-builder-2/view/change-requests/job/PR-65/10/) passes and runs the `infra` step successfully.
- Run this command to get a shell in the Terraform container and use the staging Terraform config bucket:
  ```#bash
  docker-compose -f docker-compose.ci.yml run --rm terraform
  ```
- Run `./scripts/plan` and inspect the Terraform plan output. The command should run successfully but no changes should be necessary.
- SSH into the Bastion host using the `.pem` file in the DistrictBuilder2 directory on our fileshare.
- Verify that you can connect to the RDS database. The password is available in the Terraform variables for the staging environment:
  ```#bash
  psql -U districtbuilder -h database.service.districtbuilder.internal -c "SELECT version();"
  ```