### PR TITLE
Register new user account

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-district-builder}
       - JWT_SECRET=insecure
       - JWT_EXPIRATION_IN_MS=172800000
-      - CLIENT_URL=http://localhost:3003
+      - CLIENT_URL=http://localhost:3003  # TODO: make this configurable per environment
     build:
       context: ./src/server
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-district-builder}
       - JWT_SECRET=insecure
       - JWT_EXPIRATION_IN_MS=172800000
+      - CLIENT_URL=http://localhost:3003
     build:
       context: ./src/server
       dockerfile: Dockerfile

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Redirect, Route, RouteProps, Switch } from "react-router-dom";
 
 import { getJWT, jwtIsExpired } from "./jwt";
+import ActivateScreen from "./screens/ActivateScreen";
 import HomeScreen from "./screens/HomeScreen";
 import LoginScreen from "./screens/LoginScreen";
 import ProjectScreen from "./screens/ProjectScreen";
@@ -26,6 +27,7 @@ const App = () => (
         <PrivateRoute path="/projects/:projectId" exact={true} component={ProjectScreen} />
         <Route path="/login" exact={true} component={LoginScreen} />
         <Route path="/register" exact={true} component={RegistrationScreen} />
+        <Route path="/activate/:token" exact={true} component={ActivateScreen} />
       </Switch>
     </Router>
   </div>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Redirect, Route, RouteProps, Switch } from "react-router-dom";
 
 import { getJWT, jwtIsExpired } from "./jwt";
-import ActivateScreen from "./screens/ActivateScreen";
+import ActivateAccountScreen from "./screens/ActivateAccountScreen";
 import HomeScreen from "./screens/HomeScreen";
 import LoginScreen from "./screens/LoginScreen";
 import ProjectScreen from "./screens/ProjectScreen";
@@ -27,7 +27,7 @@ const App = () => (
         <PrivateRoute path="/projects/:projectId" exact={true} component={ProjectScreen} />
         <Route path="/login" exact={true} component={LoginScreen} />
         <Route path="/register" exact={true} component={RegistrationScreen} />
-        <Route path="/activate/:token" exact={true} component={ActivateScreen} />
+        <Route path="/activate/:token" exact={true} component={ActivateAccountScreen} />
       </Switch>
     </Router>
   </div>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -5,6 +5,7 @@ import { getJWT, jwtIsExpired } from "./jwt";
 import HomeScreen from "./screens/HomeScreen";
 import LoginScreen from "./screens/LoginScreen";
 import ProjectScreen from "./screens/ProjectScreen";
+import RegistrationScreen from "./screens/RegistrationScreen";
 
 import "./App.css";
 
@@ -24,6 +25,7 @@ const App = () => (
         <Route path="/" exact={true} component={HomeScreen} />
         <PrivateRoute path="/projects/:projectId" exact={true} component={ProjectScreen} />
         <Route path="/login" exact={true} component={LoginScreen} />
+        <Route path="/register" exact={true} component={RegistrationScreen} />
       </Switch>
     </Router>
   </div>

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -13,16 +13,19 @@ if (authToken) {
   setAxiosAuthHeaders(authToken);
 }
 
+function saveJWT(jwt: JWT): void {
+  setJWT(jwt);
+  setAxiosAuthHeaders(jwt);
+}
+
 export async function authenticateUser(email: string, password: string): Promise<JWT> {
   return new Promise((resolve, reject) => {
     axios
       .post("/api/auth/email/login", { email, password })
       .then(response => {
-        // Save JWT so it can be in headers for subsequent requests
         const jwt = response.data;
-        setJWT(jwt);
-        setAxiosAuthHeaders(jwt);
-        resolve(response.data);
+        saveJWT(jwt);
+        resolve(jwt);
       })
       .catch(error => reject(error.message));
   });
@@ -42,6 +45,19 @@ export async function registerUser(name: string, email: string, password: string
     axios
       .post("/api/auth/email/register", { name, email, password })
       .then(() => resolve())
+      .catch(error => reject(error.message));
+  });
+}
+
+export async function activateAccount(token: string): Promise<JWT> {
+  return new Promise((resolve, reject) => {
+    axios
+      .post(`/api/auth/email/verify/${token}`)
+      .then(response => {
+        const jwt = response.data;
+        saveJWT(jwt);
+        resolve(jwt);
+      })
       .catch(error => reject(error.message));
   });
 }

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -36,3 +36,12 @@ export async function fetchUser(): Promise<IUser> {
       .catch(error => reject(error.message));
   });
 }
+
+export async function registerUser(name: string, email: string, password: string): Promise<IUser> {
+  return new Promise((resolve, reject) => {
+    axios
+      .post("/api/auth/email/register", { name, email, password })
+      .then(() => resolve())
+      .catch(error => reject(error.message));
+  });
+}

--- a/src/client/screens/ActivateAccountScreen.tsx
+++ b/src/client/screens/ActivateAccountScreen.tsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import { activateAccount } from "../api";
 import { Resource } from "../types";
 
-const ActivateScreen = () => {
+const ActivateAccountScreen = () => {
   const { token } = useParams();
   const [activationResource, setActivationResource] = useState<Resource<void>>({
     isPending: false
@@ -27,4 +27,4 @@ const ActivateScreen = () => {
   ) : null;
 };
 
-export default ActivateScreen;
+export default ActivateAccountScreen;

--- a/src/client/screens/ActivateScreen.tsx
+++ b/src/client/screens/ActivateScreen.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import { activateAccount } from "../api";
+import { Resource } from "../types";
+
+const ActivateScreen = () => {
+  const { token } = useParams();
+  const [activationResource, setActivationResource] = useState<Resource<void>>({
+    isPending: false
+  });
+  useEffect(() => {
+    // tslint:disable-next-line no-if-statement
+    if (token !== undefined) {
+      setActivationResource({ isPending: true });
+      activateAccount(token)
+        .then(() => setActivationResource({ resource: void 0 }))
+        .catch(errorMessage => setActivationResource({ errorMessage }));
+    }
+  }, [token]);
+  return "resource" in activationResource ? (
+    <div>Thank you for activating your account!</div>
+  ) : "errorMessage" in activationResource ? (
+    <div style={{ color: "red" }}>{activationResource.errorMessage}</div>
+  ) : "isPending" in activationResource && activationResource.isPending ? (
+    <span>Loading...</span>
+  ) : null;
+};
+
+export default ActivateScreen;

--- a/src/client/screens/HomeScreen.tsx
+++ b/src/client/screens/HomeScreen.tsx
@@ -7,6 +7,9 @@ const HomeScreen = () => (
     <br />
     <br />
     <Link to="/projects/123abc">Project 123abc</Link>
+    <br />
+    <br />
+    <Link to="/login">Login</Link> | <Link to="/register">Register</Link>
   </div>
 );
 

--- a/src/client/screens/RegistrationScreen.tsx
+++ b/src/client/screens/RegistrationScreen.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+
+import { Register } from "../../shared/entities";
+import { registerUser } from "../api";
+import { Resource } from "../types";
+
+const isFormValid = (form: RegistrationForm): boolean =>
+  Object.values(form).some(value => value.trim() === "") || form.password !== form.confirmPassword;
+
+interface RegistrationForm extends Register {
+  readonly confirmPassword: string;
+}
+
+const RegistrationScreen = () => {
+  const [registrationForm, setRegistrationForm] = useState<RegistrationForm>({
+    email: "",
+    password: "",
+    confirmPassword: "",
+    name: ""
+  });
+  const [registrationResource, setRegistrationResource] = useState<Resource<void>>({
+    isPending: false
+  });
+  const setForm = (field: keyof RegistrationForm) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setRegistrationForm({
+      ...registrationForm,
+      [field]: e.currentTarget.value
+    });
+  return "resource" in registrationResource ? (
+    <div>
+      Thanks for signing up for DistrictBuilder! Please click the link in your registration email to
+      continue.
+    </div>
+  ) : (
+    <>
+      <div>
+        <input type="text" placeholder="Name" onChange={setForm("name")} />
+      </div>
+      <div>
+        <input type="text" placeholder="Email" onChange={setForm("email")} />
+      </div>
+      <div>
+        <input type="password" placeholder="Password" onChange={setForm("password")} />
+      </div>
+      <div>
+        <input
+          type="password"
+          placeholder="Confirm password"
+          onChange={setForm("confirmPassword")}
+        />
+      </div>
+      <div>
+        <button
+          onClick={() => {
+            setRegistrationResource({ isPending: true });
+            registerUser(registrationForm.name, registrationForm.email, registrationForm.password)
+              .then(() => setRegistrationResource({ resource: void 0 }))
+              .catch(errorMessage => setRegistrationResource({ errorMessage }));
+          }}
+          disabled={
+            ("isPending" in registrationResource && registrationResource.isPending) ||
+            isFormValid(registrationForm)
+          }
+        >
+          Log in
+        </button>
+      </div>
+      {"errorMessage" in registrationResource ? (
+        <div style={{ color: "red" }}>{registrationResource.errorMessage}</div>
+      ) : null}
+    </>
+  );
+};
+
+export default RegistrationScreen;

--- a/src/client/screens/RegistrationScreen.tsx
+++ b/src/client/screens/RegistrationScreen.tsx
@@ -62,7 +62,7 @@ const RegistrationScreen = () => {
             isFormValid(registrationForm)
           }
         >
-          Log in
+          Register
         </button>
       </div>
       {"errorMessage" in registrationResource ? (

--- a/src/client/screens/RegistrationScreen.tsx
+++ b/src/client/screens/RegistrationScreen.tsx
@@ -32,7 +32,15 @@ const RegistrationScreen = () => {
       continue.
     </div>
   ) : (
-    <>
+    <form
+      onSubmit={(e: React.FormEvent) => {
+        e.preventDefault();
+        setRegistrationResource({ isPending: true });
+        registerUser(registrationForm.name, registrationForm.email, registrationForm.password)
+          .then(() => setRegistrationResource({ resource: void 0 }))
+          .catch(errorMessage => setRegistrationResource({ errorMessage }));
+      }}
+    >
       <div>
         <input type="text" placeholder="Name" onChange={setForm("name")} />
       </div>
@@ -51,12 +59,7 @@ const RegistrationScreen = () => {
       </div>
       <div>
         <button
-          onClick={() => {
-            setRegistrationResource({ isPending: true });
-            registerUser(registrationForm.name, registrationForm.email, registrationForm.password)
-              .then(() => setRegistrationResource({ resource: void 0 }))
-              .catch(errorMessage => setRegistrationResource({ errorMessage }));
-          }}
+          type="submit"
           disabled={
             ("isPending" in registrationResource && registrationResource.isPending) ||
             isFormValid(registrationForm)
@@ -68,7 +71,7 @@ const RegistrationScreen = () => {
       {"errorMessage" in registrationResource ? (
         <div style={{ color: "red" }}>{registrationResource.errorMessage}</div>
       ) : null}
-    </>
+    </form>
   );
 };
 

--- a/src/server/src/auth/services/auth.service.ts
+++ b/src/server/src/auth/services/auth.service.ts
@@ -89,8 +89,8 @@ export class AuthService {
       from: FROM_EMAIL,
       subject: "Verify your DistrictBuilder account",
       context: {
-        emailToken,
-        user
+        user,
+        url: `${process.env.CLIENT_URL}/activate/${emailToken}`
       },
       template: "verify"
     });

--- a/src/server/src/templates/verify.hbs
+++ b/src/server/src/templates/verify.hbs
@@ -1,4 +1,7 @@
-Hi <b>{{ user.name }}</b>, welcome to DistrictBuilder!
+<p>
+  Hi <b>{{ user.name }}</b>, welcome to DistrictBuilder!
+</p>
 
-To activate your account, please use this token with our frontend page that has yet to be built:
-<pre>{{ emailToken }}</pre>
+<p>
+  To activate your account, please follow this link: <a href="{{ url }}">{{ url }}</a>
+</p>


### PR DESCRIPTION
## Overview

Implement user registration

### Demo

![district_builder_register](https://user-images.githubusercontent.com/2926237/79242137-ee0c9f00-7e41-11ea-859e-4b1f67d6e35f.gif)

### Notes

I opted to just use React component state instead of using Redux, instead storing the request state in the component itself. Redux seemed like overkill since the state we want to track is dead simple, we don't care about the success response (just that the request succeeded/failed), and it's hard to imagine any other page needing to know about that state. The advantage of this is we save a bunch of boilerplate, with the potential disadvantage that it's inconsistent with how we do it other places and violates separation of concerns. I'm fine with changing it to do it the Redux/redux-loop way if anyone feels strongly about it.

## Testing Instructions
* Restart server
* Load app in browser and click "Register" link on main page
* Fill out the form with an invalid email and ensure an error message is shown
* Fill out the form with all required fields and a new, valid email address
* Should see the success page telling you to check your email
* Check the console and follow the link that shows up in the email
* You should see another success page and be logged in
* Click link back to main page and then click the project link
* Should see the email that you registered with displayed

Closes #52 
