### PR TITLE
Add API endpoints for creating and listing region configs

### DIFF
--- a/src/server/migrations/1587153603370-CreateRegionConfig.ts
+++ b/src/server/migrations/1587153603370-CreateRegionConfig.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class CreateRegionConfig1587153603370 implements MigrationInterface {
+    name = 'CreateRegionConfig1587153603370'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`CREATE TABLE "region_config" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, "country_code" character varying NOT NULL, "region_code" character varying NOT NULL, "s3_uri" character varying NOT NULL, "version" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), CONSTRAINT "UQ_07cc7193176f7610686f2730492" UNIQUE ("s3_uri"), CONSTRAINT "UQ_d2ee646fdd8506be3d136711909" UNIQUE ("name", "country_code", "region_code", "version"), CONSTRAINT "PK_2cc33eabc641c2fc526f2bb20ea" PRIMARY KEY ("id"))`, undefined);
+        await queryRunner.query(`ALTER TABLE "region_config" DROP CONSTRAINT "UQ_d2ee646fdd8506be3d136711909"`, undefined);
+        await queryRunner.query(`ALTER TABLE "region_config" ADD CONSTRAINT "UQ_d2ee646fdd8506be3d136711909" UNIQUE ("name", "country_code", "region_code", "version")`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "region_config" DROP CONSTRAINT "UQ_d2ee646fdd8506be3d136711909"`, undefined);
+        await queryRunner.query(`ALTER TABLE "region_config" ADD CONSTRAINT "UQ_d2ee646fdd8506be3d136711909" UNIQUE ("name", "country_code", "region_code", "version")`, undefined);
+        await queryRunner.query(`DROP TABLE "region_config"`, undefined);
+    }
+
+}

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -20,6 +20,7 @@
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "migration:generate": "yarn run typeorm migration:generate -n",
     "migration:create": "yarn run typeorm migration:create -n",
+    "migration:revert": "yarn run typeorm migration:revert",
     "migration:run": "yarn run typeorm migration:run"
   },
   "dependencies": {

--- a/src/server/src/app.module.ts
+++ b/src/server/src/app.module.ts
@@ -14,6 +14,7 @@ import { AppService } from "./app.service";
 import { AuthModule } from "./auth/auth.module";
 import { DistrictsModule } from "./districts/districts.module";
 import { HealthcheckService } from "./healthcheck/healthcheck.service";
+import { RegionConfigsModule } from "./region-configs/region-configs.module";
 import { UsersModule } from "./users/users.module";
 
 import { join } from "path";
@@ -52,7 +53,8 @@ const mailTransportOptions: StreamTransport.Options = {
     TerminusModule.forRootAsync({ useClass: HealthcheckService }),
     AuthModule,
     DistrictsModule,
-    UsersModule
+    UsersModule,
+    RegionConfigsModule
   ],
   controllers: [AppController],
   providers: [AppService]

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, UseGuards } from "@nestjs/common";
+import { Crud, CrudAuth, CrudController } from "@nestjsx/crud";
+
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
+import { RegionConfig } from "../entities/region-config.entity";
+import { RegionConfigsService } from "../services/region-configs.service";
+
+@Crud({
+  model: {
+    type: RegionConfig
+  },
+  routes: {
+    only: ["createOneBase", "getManyBase"]
+  },
+  params: {
+    id: {
+      type: "uuid",
+      primary: true,
+      disabled: true
+    }
+  }
+})
+@UseGuards(JwtAuthGuard)
+@Controller("api/region-configs")
+export class RegionConfigsController implements CrudController<RegionConfig> {
+  constructor(public service: RegionConfigsService) {}
+}

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -1,13 +1,8 @@
-import { Controller, InternalServerErrorException, Logger, UseGuards } from "@nestjs/common";
+import { Controller, UseGuards } from "@nestjs/common";
 import {
   Crud,
-  CrudController,
-  CrudRequest,
-  GetManyDefaultResponse,
-  Override,
-  ParsedRequest
+  CrudController
 } from "@nestjsx/crud";
-import { groupBy, last, map, sortBy } from "lodash";
 
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { RegionConfig } from "../entities/region-config.entity";
@@ -24,41 +19,5 @@ import { RegionConfigsService } from "../services/region-configs.service";
 @UseGuards(JwtAuthGuard)
 @Controller("api/region-configs")
 export class RegionConfigsController implements CrudController<RegionConfig> {
-  get base(): CrudController<RegionConfig> {
-    return this;
-  }
-  private readonly logger = new Logger(RegionConfigsController.name);
-
   constructor(public service: RegionConfigsService) {}
-
-  @Override()
-  async getMany(
-    @ParsedRequest() req: CrudRequest
-  ): Promise<GetManyDefaultResponse<RegionConfig> | readonly RegionConfig[]> {
-    if (!this.base.getManyBase) {
-      this.logger.error("Routes misconfigured. Missing `getManyBase` route");
-      throw new InternalServerErrorException();
-    }
-    const regionConfigs = await this.base.getManyBase(req);
-    if (!("length" in regionConfigs)) {
-      return regionConfigs;
-    }
-    return this.getOnlyLatestRegionConfigs(regionConfigs);
-  }
-
-  /*
-   * Only return latest version of each region config.
-   */
-  private getOnlyLatestRegionConfigs(
-    regionConfigs: readonly RegionConfig[]
-  ): readonly RegionConfig[] {
-    return map(
-      groupBy(regionConfigs, (regionConfig: RegionConfig) => [
-        regionConfig.countryCode,
-        regionConfig.regionCode,
-        regionConfig.name
-      ]),
-      (regionConfigs: RegionConfig[]) => last(sortBy(regionConfigs, "version")) as RegionConfig
-    );
-  }
 }

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, UseGuards } from "@nestjs/common";
+import { Controller, InternalServerErrorException, Logger, UseGuards } from "@nestjs/common";
 import {
   Crud,
   CrudController,
@@ -24,31 +24,41 @@ import { RegionConfigsService } from "../services/region-configs.service";
 @UseGuards(JwtAuthGuard)
 @Controller("api/region-configs")
 export class RegionConfigsController implements CrudController<RegionConfig> {
-  constructor(public service: RegionConfigsService) {}
-
   get base(): CrudController<RegionConfig> {
     return this;
   }
+  private readonly logger = new Logger(RegionConfigsController.name);
+
+  constructor(public service: RegionConfigsService) {}
 
   @Override()
   async getMany(
     @ParsedRequest() req: CrudRequest
   ): Promise<GetManyDefaultResponse<RegionConfig> | readonly RegionConfig[]> {
-    if (this.base.getManyBase) {
-      const regionConfigs = await this.base.getManyBase(req);
-      if (!("length" in regionConfigs)) {
-        return regionConfigs;
-      }
-      return map(
-        groupBy(regionConfigs, (value: RegionConfig) => [
-          value.countryCode,
-          value.regionCode,
-          value.name
-        ]),
-        (values: RegionConfig[]) => last(sortBy(values, "version")) as RegionConfig
-      );
-    } else {
-      return [];
+    if (!this.base.getManyBase) {
+      this.logger.error("Routes misconfigured. Missing `getManyBase` route");
+      throw new InternalServerErrorException();
     }
+    const regionConfigs = await this.base.getManyBase(req);
+    if (!("length" in regionConfigs)) {
+      return regionConfigs;
+    }
+    return this.getOnlyLatestRegionConfigs(regionConfigs);
+  }
+
+  /*
+   * Only return latest version of each region config.
+   */
+  private getOnlyLatestRegionConfigs(
+    regionConfigs: readonly RegionConfig[]
+  ): readonly RegionConfig[] {
+    return map(
+      groupBy(regionConfigs, (regionConfig: RegionConfig) => [
+        regionConfig.countryCode,
+        regionConfig.regionCode,
+        regionConfig.name
+      ]),
+      (regionConfigs: RegionConfig[]) => last(sortBy(regionConfigs, "version")) as RegionConfig
+    );
   }
 }

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -1,5 +1,19 @@
-import { Controller, UseGuards } from "@nestjs/common";
-import { Crud, CrudController } from "@nestjsx/crud";
+import {
+  BadRequestException,
+  Controller,
+  InternalServerErrorException,
+  Logger,
+  UseGuards
+} from "@nestjs/common";
+import {
+  Crud,
+  CrudController,
+  CrudRequest,
+  Override,
+  ParsedBody,
+  ParsedRequest
+} from "@nestjsx/crud";
+import { QueryFailedError } from "typeorm";
 
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { RegionConfig } from "../entities/region-config.entity";
@@ -16,5 +30,32 @@ import { RegionConfigsService } from "../services/region-configs.service";
 @UseGuards(JwtAuthGuard)
 @Controller("api/region-configs")
 export class RegionConfigsController implements CrudController<RegionConfig> {
+  get base(): CrudController<RegionConfig> {
+    return this;
+  }
+  private readonly logger = new Logger(RegionConfigsController.name);
   constructor(public service: RegionConfigsService) {}
+
+  @Override()
+  async createOne(
+    @ParsedRequest() req: CrudRequest,
+    @ParsedBody() dto: RegionConfig
+  ): Promise<RegionConfig> {
+    if (!this.base.createOneBase) {
+      this.logger.error("Routes misconfigured. Missing `createOneBase` route");
+      throw new InternalServerErrorException();
+    }
+    try {
+      return await this.base.createOneBase(req, dto);
+    } catch (error) {
+      if (error instanceof QueryFailedError) {
+        throw new BadRequestException(
+          "The following fields are required: name, countryCode, regionCode, s3URI. s3URI must be unique"
+        );
+      } else {
+        this.logger.error(`Error creating region config: ${error}`);
+        throw new InternalServerErrorException();
+      }
+    }
+  }
 }

--- a/src/server/src/region-configs/controllers/region-configs.controller.ts
+++ b/src/server/src/region-configs/controllers/region-configs.controller.ts
@@ -1,8 +1,5 @@
 import { Controller, UseGuards } from "@nestjs/common";
-import {
-  Crud,
-  CrudController
-} from "@nestjsx/crud";
+import { Crud, CrudController } from "@nestjsx/crud";
 
 import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard";
 import { RegionConfig } from "../entities/region-config.entity";

--- a/src/server/src/region-configs/entities/region-config.entity.ts
+++ b/src/server/src/region-configs/entities/region-config.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, PrimaryGeneratedColumn, Unique } from "typeorm";
+import { IRegionConfig } from "../../../../shared/entities";
+
+@Entity()
+@Unique(["name", "countryCode", "regionCode", "version"])
+export class RegionConfig implements IRegionConfig {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ name: "country_code" })
+  countryCode: string;
+
+  @Column({ name: "region_code" })
+  regionCode: string;
+
+  @Column({ name: "s3_uri", unique: true })
+  s3URI: string;
+
+  @Column({ type: "timestamp with time zone", default: () => "NOW()" })
+  version: Date;
+}

--- a/src/server/src/region-configs/region-configs.module.ts
+++ b/src/server/src/region-configs/region-configs.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { RegionConfigsController } from "./controllers/region-configs.controller";
+import { RegionConfig } from "./entities/region-config.entity";
+import { RegionConfigsService } from "./services/region-configs.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RegionConfig])],
+  controllers: [RegionConfigsController],
+  providers: [RegionConfigsService],
+  exports: [RegionConfigsService]
+})
+export class RegionConfigsModule {}

--- a/src/server/src/region-configs/services/region-configs.service.ts
+++ b/src/server/src/region-configs/services/region-configs.service.ts
@@ -1,13 +1,40 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
+import { CrudRequest, GetManyDefaultResponse, ParsedRequest } from "@nestjsx/crud";
 import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
+import { groupBy, last, map, sortBy } from "lodash";
 import { Repository } from "typeorm";
 
 import { RegionConfig } from "../entities/region-config.entity";
 
+// tslint:disable readonly-array
 @Injectable()
 export class RegionConfigsService extends TypeOrmCrudService<RegionConfig> {
   constructor(@InjectRepository(RegionConfig) repo: Repository<RegionConfig>) {
     super(repo);
+  }
+
+  async getMany(
+    @ParsedRequest() req: CrudRequest
+  ): Promise<GetManyDefaultResponse<RegionConfig> | RegionConfig[]> {
+    const regionConfigs = await super.getMany(req);
+    if (!("length" in regionConfigs)) {
+      return regionConfigs;
+    }
+    return this.onlyLatestRegionConfigs(regionConfigs);
+  }
+
+  /*
+   * Only return latest version of each region config.
+   */
+  private onlyLatestRegionConfigs(regionConfigs: RegionConfig[]): RegionConfig[] {
+    return map(
+      groupBy(regionConfigs, (regionConfig: RegionConfig) => [
+        regionConfig.countryCode,
+        regionConfig.regionCode,
+        regionConfig.name
+      ]),
+      (regionConfigs: RegionConfig[]) => last(sortBy(regionConfigs, "version")) as RegionConfig
+    );
   }
 }

--- a/src/server/src/region-configs/services/region-configs.service.ts
+++ b/src/server/src/region-configs/services/region-configs.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { TypeOrmCrudService } from "@nestjsx/crud-typeorm";
+import { Repository } from "typeorm";
+
+import { RegionConfig } from "../entities/region-config.entity";
+
+@Injectable()
+export class RegionConfigsService extends TypeOrmCrudService<RegionConfig> {
+  constructor(@InjectRepository(RegionConfig) repo: Repository<RegionConfig>) {
+    super(repo);
+  }
+}

--- a/src/shared/entities.d.ts
+++ b/src/shared/entities.d.ts
@@ -37,3 +37,13 @@ export type JWTPayload = IUser & {
   readonly iat: number;
   readonly sub: UserId;
 };
+
+type RegionConfigId = string;
+
+export interface IRegionConfig {
+  readonly id: RegionConfigId;
+  readonly name: string;
+  readonly countryCode: string;
+  readonly regionCode: string;
+  readonly version: Date;
+}


### PR DESCRIPTION
## Overview

Add API endpoints for creating and listing region configs

### Demo

Creating 3 region configs, two of which are for the same region (in these examples, Virginia):
```
16:00 $ http http://localhost:3003/api/region-configs/ name=Virginia countryCode=US regionCode=VA s3URI=s3://test/ing/1234 'Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiNzZlYTk4OS1jYThjLTQyZWYtYjk4My00MWJmZTg4ZjAwMTIiLCJpZCI6ImI3NmVhOTg5LWNhOGMtNDJlZi1iOTgzLTQxYmZlODhmMDAxMiIsIm5hbWUiOiJQZXRlciBDIiwiZW1haWwiOiJwZXRlcmNAYXphdmVhLmNvbSIsImlzRW1haWxWZXJpZmllZFRlc3RpbmcxMjMiOnRydWUsImlhdCI6MTU4NzA1NjEwNSwiZXhwIjoxNTg3MjI4OTA1fQ.1fxUl7Z0lcbruDFgd-p-N4jt5rcYAJaKUv87fV-paDw'
HTTP/1.1 201 Created
Vary: Accept-Encoding
connection: close
content-length: 166
content-type: application/json; charset=utf-8
date: Fri, 17 Apr 2020 20:00:41 GMT
etag: W/"a6-rICiqI9j8E9MsMX26H+Aj6A7n64"
x-powered-by: Express

{
    "countryCode": "US",
    "id": "87b88b16-286c-4058-bcd8-baa53dceb7f0",
    "name": "Virginia",
    "regionCode": "VA",
    "s3URI": "s3://test/ing/1234",
    "version": "2020-04-17T20:00:41.654Z"
}

16:01 $ http http://localhost:3003/api/region-configs/ name=Virginia countryCode=US regionCode=VA s3URI=s3://test/ing/12345 'Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e
yJzdWIiOiJiNzZlYTk4OS1jYThjLTQyZWYtYjk4My00MWJmZTg4ZjAwMTIiLCJpZCI6ImI3NmVhOTg5LWNhOGMtNDJlZ
i1iOTgzLTQxYmZlODhmMDAxMiIsIm5hbWUiOiJQZXRlciBDIiwiZW1haWwiOiJwZXRlcmNAYXphdmVhLmNvbSIsImlzR
W1haWxWZXJpZmllZFRlc3RpbmcxMjMiOnRydWUsImlhdCI6MTU4NzA1NjEwNSwiZXhwIjoxNTg3MjI4OTA1fQ.1fxUl7
Z0lcbruDFgd-p-N4jt5rcYAJaKUv87fV-paDw'
HTTP/1.1 201 Created
Vary: Accept-Encoding
connection: close
content-length: 167
content-type: application/json; charset=utf-8
date: Fri, 17 Apr 2020 20:01:59 GMT
etag: W/"a7-SbPg2UQYWa0fiXn9xC5tBq67lhs"
x-powered-by: Express

{
    "countryCode": "US",
    "id": "b1023f19-1d39-4a55-bed4-eff9d2d6be23",
    "name": "Virginia",
    "regionCode": "VA",
    "s3URI": "s3://test/ing/12345",
    "version": "2020-04-17T20:01:59.289Z"
}

16:02 $ http http://localhost:3003/api/region-configs/ name=Pennsylvania countryCode=US regi
onCode=PA s3URI=s3://test/ing/123456 'Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXV
CJ9.eyJzdWIiOiJiNzZlYTk4OS1jYThjLTQyZWYtYjk4My00MWJmZTg4ZjAwMTIiLCJpZCI6ImI3NmVhOTg5LWNhOGMt
NDJlZi1iOTgzLTQxYmZlODhmMDAxMiIsIm5hbWUiOiJQZXRlciBDIiwiZW1haWwiOiJwZXRlcmNAYXphdmVhLmNvbSIs
ImlzRW1haWxWZXJpZmllZFRlc3RpbmcxMjMiOnRydWUsImlhdCI6MTU4NzA1NjEwNSwiZXhwIjoxNTg3MjI4OTA1fQ.1
fxUl7Z0lcbruDFgd-p-N4jt5rcYAJaKUv87fV-paDw'
HTTP/1.1 201 Created
Vary: Accept-Encoding
connection: close
content-length: 172
content-type: application/json; charset=utf-8
date: Fri, 17 Apr 2020 20:03:34 GMT
etag: W/"ac-I/f9oFnsoGe1yCujHo6z/GGhaGo"
x-powered-by: Express

{
    "countryCode": "US",
    "id": "ec67c903-6a95-4080-a54f-03a41ea9810e",
    "name": "Pennsylvania",
    "regionCode": "PA",
    "s3URI": "s3://test/ing/123456",
    "version": "2020-04-17T20:03:34.466Z"
}
```

List region configs (only two are listed, not three, because only the last version is shown):
```
09:50 $ http http://localhost:3003/api/region-configs/ 'Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiNzZlYTk4OS1jYThjLTQyZWYtYjk4My00MWJmZTg4ZjAwMTIiLCJpZCI6ImI3NmVhOTg5LWNhOGMtNDJlZi1iOTgzLTQxYmZlODhmMDAxMiIsIm5hbWUiOiJQZXRlciBDIiwiZW1haWwiOiJwZXRlcmNAYXphdmVhLmNvbSIsImlzRW1haWxWZXJpZmllZCI6dHJ1ZSwiaWF0IjoxNTg3MzkwNjQzLCJleHAiOjE1ODc1NjM0NDN9.24vtYuy-IBatzGvTvC24ZjUB9F28XOjVWbCgDKusG-g'
HTTP/1.1 200 OK
Vary: Accept-Encoding
connection: close
content-length: 342
content-type: application/json; charset=utf-8
date: Mon, 20 Apr 2020 13:50:56 GMT
etag: W/"156-0tttyPn4i/0DHqMa8INMOcJ/Pzc"
x-powered-by: Express

[
    {
        "countryCode": "US",
        "id": "b1023f19-1d39-4a55-bed4-eff9d2d6be23",
        "name": "Virginia",
        "regionCode": "VA",
        "s3URI": "s3://test/ing/12345",
        "version": "2020-04-17T20:01:59.289Z"
    },
    {
        "countryCode": "US",
        "id": "ec67c903-6a95-4080-a54f-03a41ea9810e",
        "name": "Pennsylvania",
        "regionCode": "PA",
        "s3URI": "s3://test/ing/123456",
        "version": "2020-04-17T20:03:34.466Z"
    }
]
```

### Notes
There are no constraints on country code or region code for now in terms of what values they can contain, but that's probably something we should add in the future.

I added `// tslint:disable readonly-array` to the service since the NestJS CRUD types were not readonly.

## Testing Instructions
As per the steps in the demo:
* First get a JWT since these endpoints require authorization
* Create a few region configs, ensuring that you create one with the same country code, region code, and name resulting in multiple versions
* List the region configs and make sure you only get back the latest version for each

Closes #68 
