### PR TITLE
Reduce redux boilerplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "redux": "4.0.4",
     "redux-loop": "5.0.1",
     "ts.data.json": "0.3.0",
+    "typesafe-actions": "^5.1.0",
     "typescript": "3.7.2"
   },
   "eslintConfig": {

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -2,10 +2,11 @@ import { ActionType } from "typesafe-actions";
 
 import * as authActions from "./actions/auth";
 import * as projectsActions from "./actions/projects";
-import { RegionConfigAction } from "./actions/regionConfig";
+import * as regionConfigActions from "./actions/regionConfig";
 import { UserAction } from "./actions/user";
 
 export type AuthAction = ActionType<typeof authActions>;
 export type ProjectsAction = ActionType<typeof projectsActions>;
+export type RegionConfigAction = ActionType<typeof regionConfigActions>;
 
 export type Action = AuthAction | UserAction | RegionConfigAction | ProjectsAction;

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1,6 +1,10 @@
+import { ActionType } from "typesafe-actions";
+
 import { AuthAction } from "./actions/auth";
-import { ProjectsAction } from "./actions/projects";
+import * as projectsActions from "./actions/projects";
 import { RegionConfigAction } from "./actions/regionConfig";
 import { UserAction } from "./actions/user";
+
+export type ProjectsAction = ActionType<typeof projectsActions>;
 
 export type Action = AuthAction | UserAction | RegionConfigAction | ProjectsAction;

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -3,10 +3,11 @@ import { ActionType } from "typesafe-actions";
 import * as authActions from "./actions/auth";
 import * as projectsActions from "./actions/projects";
 import * as regionConfigActions from "./actions/regionConfig";
-import { UserAction } from "./actions/user";
+import * as userActions from "./actions/user";
 
 export type AuthAction = ActionType<typeof authActions>;
 export type ProjectsAction = ActionType<typeof projectsActions>;
 export type RegionConfigAction = ActionType<typeof regionConfigActions>;
+export type UserAction = ActionType<typeof userActions>;
 
 export type Action = AuthAction | UserAction | RegionConfigAction | ProjectsAction;

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -1,10 +1,11 @@
 import { ActionType } from "typesafe-actions";
 
-import { AuthAction } from "./actions/auth";
+import * as authActions from "./actions/auth";
 import * as projectsActions from "./actions/projects";
 import { RegionConfigAction } from "./actions/regionConfig";
 import { UserAction } from "./actions/user";
 
+export type AuthAction = ActionType<typeof authActions>;
 export type ProjectsAction = ActionType<typeof projectsActions>;
 
 export type Action = AuthAction | UserAction | RegionConfigAction | ProjectsAction;

--- a/src/client/actions/auth.ts
+++ b/src/client/actions/auth.ts
@@ -1,33 +1,6 @@
+import { createAction } from "typesafe-actions";
 import { JWT, Login } from "../../shared/entities";
 
-export enum ActionTypes {
-  AUTHENTICATE = "AUTHENTICATE",
-  AUTHENTICATE_SUCCESS = "AUTHENTICATE_SUCCESS",
-  AUTHENTICATE_FAILURE = "AUTHENTICATE_FAILURE"
-}
-
-export type AuthAction =
-  | { readonly type: ActionTypes.AUTHENTICATE; readonly loginForm: Login }
-  | { readonly type: ActionTypes.AUTHENTICATE_SUCCESS; readonly jwt: JWT }
-  | { readonly type: ActionTypes.AUTHENTICATE_FAILURE; readonly errorMessage: string };
-
-export function authenticate(loginForm: Login): AuthAction {
-  return {
-    type: ActionTypes.AUTHENTICATE,
-    loginForm
-  };
-}
-
-export function authenticateSuccess(jwt: JWT): AuthAction {
-  return {
-    type: ActionTypes.AUTHENTICATE_SUCCESS,
-    jwt
-  };
-}
-
-export function authenticateFailure(errorMessage: string): AuthAction {
-  return {
-    type: ActionTypes.AUTHENTICATE_FAILURE,
-    errorMessage
-  };
-}
+export const authenticate = createAction("Authenticate")<Login>();
+export const authenticateSuccess = createAction("Authenticate success")<JWT>();
+export const authenticateFailure = createAction("Authenticate failure")<string>();

--- a/src/client/actions/projects.ts
+++ b/src/client/actions/projects.ts
@@ -1,32 +1,6 @@
+import { createAction } from "typesafe-actions";
 import { IProject } from "../../shared/entities";
 
-export enum ActionTypes {
-  PROJECTS_FETCH = "PROJECTS_FETCH",
-  PROJECTS_FETCH_SUCCESS = "PROJECTS_FETCH_SUCCESS",
-  PROJECTS_FETCH_FAILURE = "PROJECTS_FETCH_FAILURE"
-}
-
-export type ProjectsAction =
-  | { readonly type: ActionTypes.PROJECTS_FETCH }
-  | { readonly type: ActionTypes.PROJECTS_FETCH_SUCCESS; readonly projects: readonly IProject[] }
-  | { readonly type: ActionTypes.PROJECTS_FETCH_FAILURE; readonly errorMessage: string };
-
-export function projectsFetch(): ProjectsAction {
-  return {
-    type: ActionTypes.PROJECTS_FETCH
-  };
-}
-
-export function projectsFetchSuccess(projects: readonly IProject[]): ProjectsAction {
-  return {
-    type: ActionTypes.PROJECTS_FETCH_SUCCESS,
-    projects
-  };
-}
-
-export function projectsFetchFailure(errorMessage: string): ProjectsAction {
-  return {
-    type: ActionTypes.PROJECTS_FETCH_FAILURE,
-    errorMessage
-  };
-}
+export const projectsFetch = createAction("Project fetch")();
+export const projectsFetchSuccess = createAction("Project fetch success")<readonly IProject[]>();
+export const projectsFetchFailure = createAction("Project fetch failure")<string>();

--- a/src/client/actions/regionConfig.ts
+++ b/src/client/actions/regionConfig.ts
@@ -1,37 +1,8 @@
+import { createAction } from "typesafe-actions";
 import { IRegionConfig } from "../../shared/entities";
 
-export enum ActionTypes {
-  REGION_CONFIGS_FETCH = "REGION_CONFIG_FETCH",
-  REGION_CONFIGS_FETCH_SUCCESS = "REGION_CONFIG_FETCH_SUCCESS",
-  REGION_CONFIGS_FETCH_FAILURE = "REGION_CONFIG_FETCH_FAILURE"
-}
-
-export type RegionConfigAction =
-  | { readonly type: ActionTypes.REGION_CONFIGS_FETCH }
-  | {
-      readonly type: ActionTypes.REGION_CONFIGS_FETCH_SUCCESS;
-      readonly regionConfigs: readonly IRegionConfig[];
-    }
-  | { readonly type: ActionTypes.REGION_CONFIGS_FETCH_FAILURE; readonly errorMessage: string };
-
-export function regionConfigsFetch(): RegionConfigAction {
-  return {
-    type: ActionTypes.REGION_CONFIGS_FETCH
-  };
-}
-
-export function regionConfigsFetchSuccess(
-  regionConfigs: readonly IRegionConfig[]
-): RegionConfigAction {
-  return {
-    type: ActionTypes.REGION_CONFIGS_FETCH_SUCCESS,
-    regionConfigs
-  };
-}
-
-export function regionConfigsFetchFailure(errorMessage: string): RegionConfigAction {
-  return {
-    type: ActionTypes.REGION_CONFIGS_FETCH_FAILURE,
-    errorMessage
-  };
-}
+export const regionConfigsFetch = createAction("Region configs fetch")();
+export const regionConfigsFetchSuccess = createAction("Region configs fetch success")<
+  readonly IRegionConfig[]
+>();
+export const regionConfigsFetchFailure = createAction("Region configs fetch failure")<string>();

--- a/src/client/actions/user.ts
+++ b/src/client/actions/user.ts
@@ -1,32 +1,6 @@
+import { createAction } from "typesafe-actions";
 import { IUser } from "../../shared/entities";
 
-export enum ActionTypes {
-  USER_FETCH = "USER_FETCH",
-  USER_FETCH_SUCCESS = "USER_FETCH_SUCCESS",
-  USER_FETCH_FAILURE = "USER_FETCH_FAILURE"
-}
-
-export type UserAction =
-  | { readonly type: ActionTypes.USER_FETCH }
-  | { readonly type: ActionTypes.USER_FETCH_SUCCESS; readonly user: IUser }
-  | { readonly type: ActionTypes.USER_FETCH_FAILURE; readonly errorMessage: string };
-
-export function userFetch(): UserAction {
-  return {
-    type: ActionTypes.USER_FETCH
-  };
-}
-
-export function userFetchSuccess(user: IUser): UserAction {
-  return {
-    type: ActionTypes.USER_FETCH_SUCCESS,
-    user
-  };
-}
-
-export function userFetchFailure(errorMessage: string): UserAction {
-  return {
-    type: ActionTypes.USER_FETCH_FAILURE,
-    errorMessage
-  };
-}
+export const userFetch = createAction("User fetch")();
+export const userFetchSuccess = createAction("User fetch success")<IUser>();
+export const userFetchFailure = createAction("User fetch failure")<string>();

--- a/src/client/reducers/auth.ts
+++ b/src/client/reducers/auth.ts
@@ -1,7 +1,8 @@
 import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
+import { getType } from "typesafe-actions";
 
 import { Action } from "../actions";
-import { ActionTypes, authenticateFailure, authenticateSuccess } from "../actions/auth";
+import { authenticate, authenticateFailure, authenticateSuccess } from "../actions/auth";
 
 import { JWT } from "../../shared/entities";
 import { authenticateUser } from "../api";
@@ -18,7 +19,7 @@ const authReducer: LoopReducer<AuthState, Action> = (
   action: Action
 ): AuthState | Loop<AuthState, Action> => {
   switch (action.type) {
-    case ActionTypes.AUTHENTICATE:
+    case getType(authenticate):
       return loop(
         {
           isPending: true
@@ -26,18 +27,18 @@ const authReducer: LoopReducer<AuthState, Action> = (
         Cmd.run(authenticateUser, {
           successActionCreator: authenticateSuccess,
           failActionCreator: authenticateFailure,
-          args: [action.loginForm.email, action.loginForm.password] as Parameters<
+          args: [action.payload.email, action.payload.password] as Parameters<
             typeof authenticateUser
           >
         })
       );
-    case ActionTypes.AUTHENTICATE_SUCCESS:
+    case getType(authenticateSuccess):
       return {
-        resource: action.jwt
+        resource: action.payload
       };
-    case ActionTypes.AUTHENTICATE_FAILURE:
+    case getType(authenticateFailure):
       return {
-        errorMessage: action.errorMessage
+        errorMessage: action.payload
       };
     default:
       return state;

--- a/src/client/reducers/projects.ts
+++ b/src/client/reducers/projects.ts
@@ -1,7 +1,8 @@
 import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
+import { getType } from "typesafe-actions";
 
 import { Action } from "../actions";
-import { ActionTypes, projectsFetchFailure, projectsFetchSuccess } from "../actions/projects";
+import { projectsFetch, projectsFetchFailure, projectsFetchSuccess } from "../actions/projects";
 
 import { IProject } from "../../shared/entities";
 import { fetchProjects } from "../api";
@@ -18,7 +19,7 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
   action: Action
 ): ProjectsState | Loop<ProjectsState, Action> => {
   switch (action.type) {
-    case ActionTypes.PROJECTS_FETCH:
+    case getType(projectsFetch):
       return loop(
         {
           isPending: true
@@ -29,13 +30,13 @@ const projectsReducer: LoopReducer<ProjectsState, Action> = (
           args: []
         })
       );
-    case ActionTypes.PROJECTS_FETCH_SUCCESS:
+    case getType(projectsFetchSuccess):
       return {
-        resource: action.projects
+        resource: action.payload
       };
-    case ActionTypes.PROJECTS_FETCH_FAILURE:
+    case getType(projectsFetchFailure):
       return {
-        errorMessage: action.errorMessage
+        errorMessage: action.payload
       };
     default:
       return state;

--- a/src/client/reducers/regionConfig.ts
+++ b/src/client/reducers/regionConfig.ts
@@ -1,8 +1,9 @@
 import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
+import { getType } from "typesafe-actions";
 
 import { Action } from "../actions";
 import {
-  ActionTypes,
+  regionConfigsFetch,
   regionConfigsFetchFailure,
   regionConfigsFetchSuccess
 } from "../actions/regionConfig";
@@ -22,7 +23,7 @@ const regionConfigReducer: LoopReducer<RegionConfigState, Action> = (
   action: Action
 ): RegionConfigState | Loop<RegionConfigState, Action> => {
   switch (action.type) {
-    case ActionTypes.REGION_CONFIGS_FETCH:
+    case getType(regionConfigsFetch):
       return loop(
         {
           isPending: true
@@ -33,13 +34,13 @@ const regionConfigReducer: LoopReducer<RegionConfigState, Action> = (
           args: []
         })
       );
-    case ActionTypes.REGION_CONFIGS_FETCH_SUCCESS:
+    case getType(regionConfigsFetchSuccess):
       return {
-        resource: action.regionConfigs
+        resource: action.payload
       };
-    case ActionTypes.REGION_CONFIGS_FETCH_FAILURE:
+    case getType(regionConfigsFetchFailure):
       return {
-        errorMessage: action.errorMessage
+        errorMessage: action.payload
       };
     default:
       return state;

--- a/src/client/reducers/user.ts
+++ b/src/client/reducers/user.ts
@@ -1,7 +1,8 @@
 import { Cmd, Loop, loop, LoopReducer } from "redux-loop";
+import { getType } from "typesafe-actions";
 
 import { Action } from "../actions";
-import { ActionTypes, userFetchFailure, userFetchSuccess } from "../actions/user";
+import { userFetch, userFetchFailure, userFetchSuccess } from "../actions/user";
 
 import { IUser } from "../../shared/entities";
 import { fetchUser } from "../api";
@@ -18,7 +19,7 @@ const userReducer: LoopReducer<UserState, Action> = (
   action: Action
 ): UserState | Loop<UserState, Action> => {
   switch (action.type) {
-    case ActionTypes.USER_FETCH:
+    case getType(userFetch):
       return loop(
         {
           isPending: true
@@ -29,13 +30,13 @@ const userReducer: LoopReducer<UserState, Action> = (
           args: []
         })
       );
-    case ActionTypes.USER_FETCH_SUCCESS:
+    case getType(userFetchSuccess):
       return {
-        resource: action.user
+        resource: action.payload
       };
-    case ActionTypes.USER_FETCH_FAILURE:
+    case getType(userFetchFailure):
       return {
-        errorMessage: action.errorMessage
+        errorMessage: action.payload
       };
     default:
       return state;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10086,6 +10086,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typesafe-actions@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-5.1.0.tgz#9afe8b1e6a323af1fd59e6a57b11b7dd6623d2f1"
+  integrity sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==
+
 typescript@3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"


### PR DESCRIPTION
## Overview

This PR brings in the library [`typesafe-actions`](https://github.com/piotrwitek/typesafe-actions) to reduce some repeated boilerplate in creating new Redux actions

### Demo

N/A

### Notes

I initially tried using `redux-act`, but ran into issues when combining it with `redux-loop`. `typesafe-actions` let me convert just the action side but stick to largely the same pattern already in place for the reducers, which dealt with the bulk of the boilerplate issues we were encountering.

## Testing Instructions

- `scripts/update`

Closes #95 