### PR TITLE
Fix convertValidationErrors typing issue

### DIFF
--- a/src/server/src/common/bad-request-exception.filter.ts
+++ b/src/server/src/common/bad-request-exception.filter.ts
@@ -7,11 +7,12 @@ function convertValidationErrors(
 ): {
   [field: string]: readonly string[];
 } {
-  return Object.fromEntries(
-    errors.map((error: ValidationError) => {
-      return [error.property, Object.values(error.constraints)];
+  const fieldErrors = errors
+    .map((error: ValidationError) => {
+      return error.constraints ? [error.property, Object.values(error.constraints)] : undefined;
     })
-  );
+    .filter(item => item !== undefined) as Array<[string, string[]]>;
+  return Object.fromEntries(fieldErrors);
 }
 
 /**


### PR DESCRIPTION
## Overview

PR #100 was unintentionally broken after merging, due to a problem uncovered by adding a stricter type to the `convertValidationErrors` function.

According to the typings `constraints` could be undefined here.
I didn't see that happen when testing but we should guard against it regardless.

## Notes

It's a bit alarming that `scripts/update` & `scripts/server` are broken on `develop` but CI passed for #100.

## Testing Instructions

- `scripts/server` should work
